### PR TITLE
Fix joined fields in large lap code

### DIFF
--- a/lapdecompile/scanner.py
+++ b/lapdecompile/scanner.py
@@ -110,6 +110,10 @@ class LapScanner:
             fields = line.split()
             if len(fields) == 0:
                 break
+            joined_field = re.match(r"(\d+:\d+)(\D.+)", fields[0])
+            if joined_field:
+                fields[0] = joined_field.group(1)
+                fields.insert(1, joined_field.group(2))
             offset = fields[0]
             colon_point = offset.find(":")
             if colon_point >= 0:


### PR DESCRIPTION
When lap code is large, Emacs will not leave a gap between the first and second fields. Like this:

```lisp
3452:146stack-ref 4
```

This change detects this case and properly splits the field.